### PR TITLE
Remove until build restriction

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ platformPlugins = JavaScriptLanguage
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency = false
+…

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = com.github.inxilpro.intellijalpine
 pluginName_ = Alpine.js Support
 pluginVersion = 0.0.3
 pluginSinceBuild = 193
-pluginUntilBuild = 202.*
+pluginUntilBuild =
 
 platformType = IU
 platformVersion = 2020.2
@@ -17,4 +17,3 @@ platformPlugins = JavaScriptLanguage
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency = false
-…

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/AttributesProvider.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/AttributesProvider.kt
@@ -34,7 +34,8 @@ class AttributesProvider : XmlAttributeDescriptorsProvider {
         return null
     }
 
-    private class AttributeDescriptor(private val name: String) : BasicXmlAttributeDescriptor(),
+    private class AttributeDescriptor(private val name: String) :
+        BasicXmlAttributeDescriptor(),
         PsiPresentableMetaData {
         override fun getIcon() = Alpine.ICON
 


### PR DESCRIPTION
I tried installing the plugin in PHPStorm but because I run the latest EAP version it wouldn't install. I have cleared out the `pluginUntilBuild` property as I think this only needs to be set when the plugin will be deprecated. I ran and tested this change and everything seems to work fine.

This will resolve #2, I could also update the version number of the plugin if you want me to 😄 

Thanks for the awesome plugin!