### PR TITLE
Allow alpine directives in blade components

### DIFF
--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/AlpineJavaScriptAttributeValueInjector.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/AlpineJavaScriptAttributeValueInjector.kt
@@ -135,12 +135,13 @@ class AlpineJavaScriptAttributeValueInjector : MultiHostInjector {
 
         // Make sure we have an HTML tag (and not a Blade <x- tag)
         val tag = attribute.parent as? HtmlTag ?: return false
-        if (!isValidHtmlTag(tag)) {
+        val attributeName = attribute.name
+
+        if (isBladeComponentBindAttribute(tag, attributeName)) {
             return false
         }
 
         // Make sure we have an attribute that looks like it's Alpine
-        val attributeName = attribute.name
         if (!isAlpineAttributeName(attributeName)) {
             return false
         }
@@ -162,8 +163,10 @@ class AlpineJavaScriptAttributeValueInjector : MultiHostInjector {
         return attribute.descriptor is HtmlAttributeDescriptorImpl || attribute.descriptor is AlpineAttributeDescriptor
     }
 
-    private fun isValidHtmlTag(tag: HtmlTag): Boolean {
-        return !tag.name.startsWith("x-")
+    private fun isBladeComponentBindAttribute(tag: HtmlTag, name: String): Boolean {
+        return AttributeUtil.isBladeComponentTag(tag)
+                && name.startsWith(":")
+                && !name.startsWith("::")
     }
 
     private fun isAlpineAttributeName(name: String): Boolean {

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/AttributeUtil.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/AttributeUtil.kt
@@ -109,8 +109,19 @@ object AttributeUtil {
         return xmlPrefixes.contains(prefix)
     }
 
+    fun isBladeComponentTag(htmlTag: HtmlTag): Boolean {
+        return htmlTag.name.startsWith("x-")
+    }
+
     fun getValidAttributesWithInfo(xmlTag: HtmlTag): Array<AttributeInfo> {
         return validAttributes.getOrPut(xmlTag.name, { buildValidAttributes(xmlTag) })
+    }
+
+    fun getBindPrefixes(htmlTag: HtmlTag): Array<String> {
+        if(isBladeComponentTag(htmlTag)) {
+            return arrayOf("::", "x-bind:");
+        }
+        return bindPrefixes;
     }
 
     fun isEvent(attribute: String): Boolean {
@@ -123,8 +134,8 @@ object AttributeUtil {
         return false
     }
 
-    fun isBound(attribute: String): Boolean {
-        for (prefix in bindPrefixes) {
+    fun isBound(attribute: String, htmlTag: HtmlTag): Boolean {
+        for (prefix in getBindPrefixes(htmlTag)) {
             if (attribute.startsWith(prefix)) {
                 return true
             }
@@ -151,7 +162,7 @@ object AttributeUtil {
                     descriptors.add(AttributeInfo(prefix + event))
                 }
             } else {
-                for (prefix in bindPrefixes) {
+                for (prefix in getBindPrefixes(htmlTag)) {
                     descriptors.add(AttributeInfo(prefix + descriptor.name))
                 }
             }

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/AutoCompleteSuggestions.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/AutoCompleteSuggestions.kt
@@ -44,7 +44,7 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
     }
 
     private fun addDerivedAttributes() {
-        if (!AttributeUtil.isEvent(partialAttribute) && !AttributeUtil.isBound(partialAttribute)) {
+        if (!AttributeUtil.isEvent(partialAttribute) && !AttributeUtil.isBound(partialAttribute, htmlTag)) {
             return
         }
 
@@ -89,7 +89,7 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
     }
 
     private fun addBoundAttribute(descriptor: XmlAttributeDescriptor) {
-        for (prefix in AttributeUtil.bindPrefixes) {
+        for (prefix in AttributeUtil.getBindPrefixes(htmlTag)) {
             descriptors.add(AttributeInfo(prefix + descriptor.name))
         }
     }


### PR DESCRIPTION
Hi! This PR aim to allow alpine directive for blade `<x-` components.

Features:
- js injection like for classic html tag
- allow `::` bind prefix

TODO:
- [ ] Find why attributes hasn't `AlpineAttributeDescriptor` attached inside `<x-` components
- [ ] Test with laravel-idea

This is currently not working because attributes hasn't `AlpineAttributeDescriptor` attached. Injection works by commenting [`isValidAttribute()` check](https://github.com/inxilpro/IntellijAlpine/blob/main/src/main/kotlin/com/github/inxilpro/intellijalpine/AlpineJavaScriptAttributeValueInjector.kt#L149). I am missing something here, any idea @inxilpro  ?