### PR TITLE
Make $el and $root typed, based on the HTML tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Added support for IntelliJ platform version 2023.2
 - Added support for [`glhd/alpine-wizard`](https://github.com/glhd/alpine-wizard)
+- Added typing support for `$el` and `$root`
 
 ## [0.5.0] - 2023-05-31
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = com.github.inxilpro.intellijalpine
 pluginName = Alpine.js Support
 pluginRepositoryUrl = https://github.com/inxilpro/IntellijAlpine
 # SemVer format -> https://semver.org
-pluginVersion = 0.6.0
+pluginVersion = 0.6.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 231


### PR DESCRIPTION
This pull request makes it so `$el` and `$root` types are inferred from the HTML file being edited:
- `$el` will be inferred to the current tag.
- `$root` will be inferred to the closest parent tag with the `x-data` attribute, if any (defaults to `HTMLElement`).