### PR TITLE
Remove the upper compatibility bound

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ pluginRepositoryUrl = https://github.com/inxilpro/IntellijAlpine
 pluginVersion = 0.7.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# No upper bound: the plugin stays compatible with current and future platforms (verified via the plugin verifier).
 pluginSinceBuild = 251
-pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
Drop pluginUntilBuild so the plugin is not artificially capped at a specific platform build. Compatibility with current and future IDE versions is verified via the IntelliJ Plugin Verifier instead.