### PR TITLE
Upgrade build tooling: Gradle 9, IntelliJ Platform 2.16, Kotlin 2.3.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,8 +131,8 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            // Only verify against the current version to speed up CI
-            ide("IU-2025.1")
+            // The 2.x verifier API replaced ide("...") notation; verify against JetBrains' recommended IDE set.
+            recommended()
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ platformPlugins =
 platformBundledPlugins = JavaScript,HtmlTools
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.13
+gradleVersion = 9.0.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,8 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.6.0"
-kotlin = "2.1.21"
+intelliJPlatform = "2.16.0"
+kotlin = "2.3.20"
 kover = "0.9.1"
 qodana = "2025.1.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Second split, as promised. Pure build-tooling upgrade.
- Gradle `8.13 -> 9.0.0` 
- IntelliJ Platform Gradle Plugin `2.6.0 -> 2.16.0` 
- Kotlin `2.1.21 -> 2.3.20`.

**Note:** The 2.16 plugin verifier API dropped the `ide("...")` notation, so the pluginVerification block is updated to use `recommended()` instead. Verified locally with `compileKotlin` against the current 2025.1 platform.