### PR TITLE
Support `x-resize` directive

### DIFF
--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeInfo.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeInfo.kt
@@ -35,6 +35,7 @@ class AttributeInfo(val attribute: String) {
         "x-intersect" to "Bind an intersection observer",
         "x-trap" to "Add focus trap",
         "x-collapse" to "Collapse element when hidden",
+        "x-resize" to "Listen to element size changes using ResizeObserver",
     )
 
     val name: String

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeUtil.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeUtil.kt
@@ -44,6 +44,7 @@ object AttributeUtil {
         "x-intersect",
         "x-trap",
         "x-collapse",
+        "x-resize",
         "x-spread", // deprecated
     )
 
@@ -125,6 +126,10 @@ object AttributeUtil {
 
     val intersectModifiers = arrayOf(
         "once"
+    )
+
+    val resizeModifiers = arrayOf(
+        "document"
     )
 
     // Taken from https://developer.mozilla.org/en-US/docs

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/completion/AutoCompleteSuggestions.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/completion/AutoCompleteSuggestions.kt
@@ -38,6 +38,10 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
             if ("x-intersect" == directive) {
                 addModifiers(directive, AttributeUtil.intersectModifiers)
             }
+
+            if ("x-resize" == directive) {
+                addModifiers(directive, AttributeUtil.resizeModifiers)
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/injection/AlpineJavaScriptAttributeValueInjector.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/injection/AlpineJavaScriptAttributeValueInjector.kt
@@ -85,6 +85,16 @@ class AlpineJavaScriptAttributeValueInjector : MultiHostInjector {
 
     private val eventMagics = "/** @type {eventType} */\nlet ${'$'}event;\n\n"
 
+    private val resizeMagics =
+        """
+            /** @type number */
+            let ${'$'}width;
+
+            /** @type number */
+            let ${'$'}height;
+                    
+        """.trimIndent()
+
     override fun getLanguagesToInject(registrar: MultiHostRegistrar, host: PsiElement) {
         if (host !is XmlAttributeValue) {
             return
@@ -170,6 +180,8 @@ class AlpineJavaScriptAttributeValueInjector : MultiHostInjector {
         } else if ("x-teleport" == directive) {
             context.left += "{ /** @var {HTMLElement} teleport */let teleport = "
             context.right += " }"
+        } else if ("x-resize" == directive) {
+            context.left += resizeMagics
         } else if ("x-init" == directive) {
             // We want x-init to skip the directive wrapping
         } else {


### PR DESCRIPTION
Support [x-resize](https://alpinejs.dev/plugins/resize) directive with its `$width`, `$height` magics + `.document` modifier.