### PR TITLE
Disable `x-effect` attribute wrapping

### DIFF
--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/injection/AlpineJavaScriptAttributeValueInjector.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/injection/AlpineJavaScriptAttributeValueInjector.kt
@@ -170,8 +170,8 @@ class AlpineJavaScriptAttributeValueInjector : MultiHostInjector {
         } else if ("x-teleport" == directive) {
             context.left += "{ /** @var {HTMLElement} teleport */let teleport = "
             context.right += " }"
-        } else if ("x-init" == directive) {
-            // We want x-init to skip the directive wrapping
+        } else if ("x-init" == directive || "x-effect" == directive) {
+            // We want x-init and x-effect to skip the directive wrapping
         } else {
             context.left += "__ALPINE_DIRECTIVE(\n"
             context.right += "\n)"


### PR DESCRIPTION
The [x-effect](https://alpinejs.dev/directives/effect) directive should not be wrapped around `__ALPINE_DIRECTIVE()` because its expression is not expected to be a single returned value. It can be complex / multiline expression (which currently throws an inspection error), e.g :

```html
<div
  x-data="{ label: 'Hello' }"
  x-effect="
    console.log(label);
    if(!label) { alert('Invalid label') }
  "
></div>
```