### PR TITLE
Automate post-release changelog and version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,8 +230,26 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
+      # A draft for an already-published version duplicates a shipped release, and publishing it
+      # would overwrite that version on the Marketplace with whatever is on main.
+      - name: Check Version Is Unreleased
+        id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.build.outputs.version }}
+        run: |
+          DRAFT="$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || true)"
+
+          if [ "$DRAFT" = "false" ]; then
+            echo "::warning::$TAG is already published — skipping release draft. Bump pluginVersion in gradle.properties."
+            echo "unreleased=false" >> $GITHUB_OUTPUT
+          else
+            echo "unreleased=true" >> $GITHUB_OUTPUT
+          fi
+
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts
+        if: steps.version.outputs.unreleased == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -241,6 +259,7 @@ jobs:
 
       # Create a new release draft which is not publicly visible and requires manual acceptance
       - name: Create Release Draft
+        if: steps.version.outputs.unreleased == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      changelog: ${{ steps.properties.outputs.changelog }}
     steps:
 
       # Check out current repository
@@ -30,13 +32,11 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-home-cache-cleanup: true
+        uses: gradle/actions/setup-gradle@v4
 
       # Set environment variables
       - name: Export Properties
@@ -75,29 +75,92 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
-      # Create pull request
+  # Open a pull request against the default branch that files the release notes under the
+  # published version and bumps pluginVersion, so the default branch never sits on a version
+  # that has already shipped. Skipped for pre-releases, which keep iterating the same version.
+  postRelease:
+    name: Post-release update
+    needs: [ release ]
+    if: github.event.action == 'released' && !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+
+      # Check out the default branch rather than the release tag, so the pull request only
+      # contains these updates and does not revert anything merged since the tag
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Move the release notes out of the Unreleased section and into the published version
+      - name: Patch Changelog
+        env:
+          CHANGELOG: ${{ needs.release.outputs.changelog }}
+        run: |
+          if [ -n "$CHANGELOG" ]; then
+            ./gradlew patchChangelog --release-note="$CHANGELOG"
+          else
+            ./gradlew patchChangelog
+          fi
+
+      # Bump the patch version. A maintainer can still choose a minor or major bump by hand
+      # before the next release; this only guarantees the version is never a published one.
+      - name: Bump Plugin Version
+        id: bump
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          RELEASED="${TAG#v}"
+          CURRENT="$(sed -n 's/^pluginVersion = //p' gradle.properties)"
+
+          if [ "$CURRENT" != "$RELEASED" ]; then
+            echo "::notice::pluginVersion is $CURRENT but $RELEASED was released — leaving it alone."
+            exit 0
+          fi
+
+          NEXT="$(echo "$RELEASED" | awk -F. -v OFS=. '{ $3 += 1; print }')"
+          sed -i "s/^pluginVersion = .*/pluginVersion = $NEXT/" gradle.properties
+          echo "next=$NEXT" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name }}
+          NEXT: ${{ steps.bump.outputs.next }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::notice::Nothing to update after $VERSION."
+            exit 0
+          fi
+
+          BRANCH="post-release-$VERSION"
           LABEL="release changelog"
 
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
 
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
+          git checkout -b "$BRANCH"
+          git commit -am "Post-release update - $VERSION"
+          git push --set-upstream origin "$BRANCH"
+
           gh label create "$LABEL" \
             --description "Pull requests with release changelog update" \
             || true
 
           gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
+            --title "Post-release update - \`$VERSION\`" \
+            --body "Files the \`$VERSION\` release notes in \`CHANGELOG.md\`${NEXT:+ and bumps \`pluginVersion\` to \`$NEXT\`}." \
             --label "$LABEL" \
-            --head $BRANCH
+            --head "$BRANCH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [Unreleased]
 
 ### Changed
+- Removed the upper compatibility bound so the plugin is not capped at a specific platform build
+- Plugin detection now runs on a background thread
+
+## [0.7.0] - 2025-06-21
+
+### Changed
 - Improved support for [alpine-wizard](https://github.com/glhd/alpine-wizard)
 - Improved overall performance of plugin
 
@@ -151,7 +157,8 @@ A bug was introduced that impacted Alpine when you did something like `x-data="@
 ### Fixed
 - Removed Alpine icon which seemed to cause issues for some people
 
-[Unreleased]: https://github.com/inxilpro/IntellijAlpine/compare/v0.6.6...HEAD
+[Unreleased]: https://github.com/inxilpro/IntellijAlpine/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/inxilpro/IntellijAlpine/compare/v0.6.6...v0.7.0
 [0.6.6]: https://github.com/inxilpro/IntellijAlpine/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/inxilpro/IntellijAlpine/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/inxilpro/IntellijAlpine/compare/v0.6.3...v0.6.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,10 @@ The plugin requires:
 
 ### Release Process
 
-1. Update version in `gradle.properties`
-2. Update `CHANGELOG.md` Unreleased section with version number
-3. Push changes to main branch
-4. Create and publish a GitHub release - this triggers automatic publishing to JetBrains Marketplace
+1. Land the changes on main. Each push to main refreshes a draft GitHub release for the current
+   `pluginVersion`, using the `CHANGELOG.md` Unreleased section as its notes. The draft is skipped
+   if that version has already been published.
+2. Publish the draft release - this triggers automatic publishing to JetBrains Marketplace
+3. The release workflow then opens a "Post-release update" pull request that files the notes under
+   the published version in `CHANGELOG.md` and bumps `pluginVersion` to the next patch. Merge it,
+   editing the version by hand first if the next release should be a minor or major bump.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.inxilpro.intellijalpine
 pluginName = Alpine.js Support
 pluginRepositoryUrl = https://github.com/inxilpro/IntellijAlpine
 # SemVer format -> https://semver.org
-pluginVersion = 0.7.0
+pluginVersion = 0.7.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # No upper bound: the plugin stays compatible with current and future platforms (verified via the plugin verifier).


### PR DESCRIPTION
## Summary

This PR refactors the release workflow to automate post-release tasks, eliminating manual steps and ensuring the default branch never sits on an already-published version. The workflow now creates a draft release on every push to main (if the version is unreleased), and automatically opens a pull request after publishing to file release notes and bump the version.

## Key Changes

- **Release workflow restructuring**: Split release logic into two jobs:
  - `release`: Publishes the release and uploads artifacts
  - `postRelease`: Opens a PR to update changelog and bump version (skipped for pre-releases)

- **Automated changelog management**: The `postRelease` job runs `patchChangelog` to move release notes from the Unreleased section into the published version, then bumps `pluginVersion` to the next patch version

- **Version safety checks**: Added validation in the build workflow to prevent creating release drafts for already-published versions, with a warning to bump `pluginVersion`

- **Java and Gradle updates**:
  - Upgraded Java version from 17 to 21
  - Updated Gradle setup action from `gradle/gradle-build-action@v3` to `gradle/actions/setup-gradle@v4`

- **Documentation updates**: Updated `CLAUDE.md` to reflect the new automated release process

- **Changelog and version bump**: Filed v0.7.0 release notes and bumped version to 0.7.1

## Implementation Details

- The `release` job now exports the changelog via outputs for use in the `postRelease` job
- The `postRelease` job checks out the default branch (not the release tag) to ensure the PR only contains the new updates
- Version bumping uses a simple patch increment; maintainers can manually edit the version before merging if a minor/major bump is needed
- The workflow gracefully handles cases where nothing needs updating after a release

https://claude.ai/code/session_01H7JWngMFwGyzVHPjrWcK69