### PR TITLE
Handle `x-intersect:enter` & `x-intersect:leave`

### DIFF
--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeInfo.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeInfo.kt
@@ -33,6 +33,8 @@ class AttributeInfo(val attribute: String) {
         "x-bind" to "Bind an attribute",
         "x-mask" to "Set input mask",
         "x-intersect" to "Bind an intersection observer",
+        "x-intersect:enter" to "Bind an intersection observer and trigger when entering viewport",
+        "x-intersect:leave" to "Bind an intersection observer and trigger when leaving viewport",
         "x-trap" to "Add focus trap",
         "x-collapse" to "Collapse element when hidden",
         "x-resize" to "Listen to element size changes using ResizeObserver",

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeUtil.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/attributes/AttributeUtil.kt
@@ -13,6 +13,7 @@ object AttributeUtil {
         "x-on",
         "x-bind",
         "x-transition",
+        "x-intersect",
     )
 
     val prefixes: List<String> by lazy {

--- a/src/main/kotlin/com/github/inxilpro/intellijalpine/completion/AutoCompleteSuggestions.kt
+++ b/src/main/kotlin/com/github/inxilpro/intellijalpine/completion/AutoCompleteSuggestions.kt
@@ -20,6 +20,7 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
         addPrefixes()
         addDerivedAttributes()
         addTransitions()
+        addIntersect()
         addPlugins()
     }
 
@@ -33,10 +34,6 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
 
             if ("x-model" == directive) {
                 addModifiers(directive, AttributeUtil.modelModifiers)
-            }
-
-            if ("x-intersect" == directive) {
-                addModifiers(directive, AttributeUtil.intersectModifiers)
             }
 
             if ("x-resize" == directive) {
@@ -80,6 +77,20 @@ class AutoCompleteSuggestions(val htmlTag: HtmlTag, val partialAttribute: String
         for (stage in stages) {
             descriptors.add(AttributeInfo("x-transition:$stage"))
             addModifiers("x-transition:$stage", AttributeUtil.transitionModifiers)
+        }
+    }
+
+    private fun addIntersect() {
+        val stages: Array<String> = arrayOf(
+            "enter",
+            "leave"
+        )
+
+        addModifiers("x-intersect", AttributeUtil.intersectModifiers)
+
+        for (stage in stages) {
+            descriptors.add(AttributeInfo("x-intersect:$stage"))
+            addModifiers("x-intersect:$stage", AttributeUtil.intersectModifiers)
         }
     }
 


### PR DESCRIPTION
`x-intersect` supports `:enter` & `:leave` suffixes (https://alpinejs.dev/plugins/intersect#x-intersect), this PR allow injection & autocompletion of these cases.